### PR TITLE
Arreglo para reemplazar resultados de búsqueda

### DIFF
--- a/script.js
+++ b/script.js
@@ -9,6 +9,7 @@ function fetchBooks() {
         fetch(`https://openlibrary.org/search.json?${opcion}=${searchBox.value}&limit=10`)
         .then((resp) => resp.json())
         .then((data) => {
+            contenedor2.innerHTML = "";
             mostrarResultados(data.docs);
         });
     }


### PR DESCRIPTION
He añadido una línea al código JavaScript para que vacíe el contenido del "contenedor2" antes de mostrar los nuevos resultados de búsqueda. Una cosa que me percaté en detalle para lo del trabajo